### PR TITLE
Add Collection Management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+3D Model Muncher is a full-stack web app for organizing, searching, and previewing 3D printing models (`.3mf`, `.stl`) with metadata management, G-code analysis, and optional AI-powered suggestions via Google Gemini.
+
+## Development Commands
+
+**First-time / after changing backend utilities:**
+```bash
+npm run build:backend   # Compile src/utils/*.ts → dist-backend/utils/ (required before running server)
+```
+
+**Running locally (two terminals):**
+```bash
+npm run server   # Terminal 1: Express backend on port 3001
+npm run dev      # Terminal 2: Vite dev server on port 3000 (proxies /api and /models to :3001)
+```
+
+**Other commands:**
+```bash
+npm run build           # Vite production build → build/
+npm run preview         # Serve production build on port 4173 (still needs backend on :3001)
+npm run test            # Run full Vitest suite
+npm run test:watch      # Vitest in watch mode
+```
+
+**Running a single test file:**
+```bash
+npx vitest run tests/gcodeParser.test.ts
+```
+
+## Architecture
+
+### Frontend/Backend Split
+
+- **Frontend** (`src/`): React 18 + Vite 6 + Tailwind CSS 4 + Radix UI. Entry: `src/main.tsx` → `src/App.tsx`.
+- **Backend** (`server.js`): Single ~3200-line Express 5 file handling all API routes, file scanning, and static serving.
+- **Backend Utilities** (`src/utils/`): TypeScript modules shared between frontend and backend. They are compiled separately via `tsconfig.backend.json` to CommonJS in `dist-backend/utils/`. The main `tsconfig.json` has `noEmit: true` (Vite handles frontend compilation), so backend utilities **must** use the separate config.
+
+### Data Storage (File-Based, No Database)
+
+- `models/*-munchie.json` — metadata for each 3D model
+- `data/config.json` — app configuration
+- `data/collections.json` — user-defined model groups
+
+### Key Backend Utilities (edit in `src/utils/`, then run `npm run build:backend`)
+
+- **`gcodeParser.ts`** — Parses `.gcode` and `.gcode.3mf` (BambuLab archive format). Extracts print time, filament usage, and filament colors. Case-insensitive comment parsing. Distinguishes `filament_colour` (hex like `#FFFFFF`) from `filament_colour_type` (numeric codes).
+- **`threeMFToJson.ts`** — Extracts metadata, thumbnails (as base64), and MD5 hash from `.3mf`/`.stl` files.
+- **`configManager.ts`** — Loads/saves `data/config.json`; manages per-worker test config isolation.
+
+### Model Metadata Lifecycle
+
+Each `.3mf` or `.stl` file gets a `-munchie.json` sidecar. On metadata regeneration:
+- **Preserved (user data):** `tags`, `isPrinted`, `printTime`, `filamentUsed`, `category`, `notes`, `license`, `hidden`, `source`, `price`, `related_files`, `gcodeData`, `userDefined`
+- **Refreshed from file:** thumbnails, name, designer, dimensions, print settings (for `.3mf` only)
+
+### Print Settings Ownership
+
+- **`.3mf` files:** `printSettings` come from the parsed 3MF file. UI inputs are hidden; regenerate always overwrites them from the file.
+- **`.stl` files:** `printSettings` are user-managed and persist across saves and regenerate. UI inputs are shown and editable.
+- **BulkEditDrawer:** Print settings only apply to STL selections; blank inputs mean "no change."
+
+### G-code Integration
+
+- Storage modes: `parse-only` (default, no file saved) or `save-and-link` (saves file and adds to `related_files`).
+- `.gcode.3mf` archives are saved as binary (not converted to text) to preserve BambuLab metadata.
+- G-code data is stored in the `gcodeData` field in `munchie.json`.
+- Unit tests: `tests/gcodeParser.test.ts`, fixtures: `tests/fixtures/gcode/`.
+
+### Settings Architecture
+
+- `SettingsPage.tsx` is now a thin shell; all content lives in `src/components/settings/`:
+  - `SettingsSidebar.tsx` — tab navigation sidebar (controlled by `App.tsx`)
+  - Tab components: `GeneralTab`, `CategoriesTab`, `TagsTab`, `ConfigTab`, `BackupTab`, `IntegrityTab`, `SupportTab`
+
+### Testing
+
+- Vitest 4 with jsdom environment.
+- `vitest.config.ts` configures the test environment and sets `@` as an alias for `src/`.
+- `vitest.setup.ts` mocks Radix UI primitives (Checkbox, Select, Slider, DropdownMenu) to test-friendly HTML elements — new component tests using these work without extra setup.
+- Component tests live in `tests/components/`.
+- Tests use an isolated collections file (`data/collections.test.json`) and per-worker config files (`data/config.vitest-*.json`) to prevent interference during parallel runs.
+- Server/API tests are in `tests/server/`.
+
+### Docker
+
+Multi-stage Dockerfile: builder stage (`npm run build` + `npm run build:backend`), then production stage copies `build/`, `dist-backend/`, `server.js`, and `server-utils/`. The backend serves both the API and the frontend static files from a single port (3001).

--- a/server.js
+++ b/server.js
@@ -156,13 +156,73 @@ const collectionsFilePath = (() => {
   return defaultPath;
 })();
 
+function uniqueStringArray(values) {
+  if (!Array.isArray(values)) return [];
+  return Array.from(new Set(values.filter(value => typeof value === 'string' && value.trim() !== '')));
+}
+
+function normalizeCollectionGroups(groups, allowedModelIds = null) {
+  if (!Array.isArray(groups) || groups.length === 0) return [];
+
+  const allowed = Array.isArray(allowedModelIds) ? new Set(uniqueStringArray(allowedModelIds)) : null;
+  const seenModelIds = new Set();
+  const normalized = [];
+
+  for (const group of groups) {
+    if (!group || typeof group !== 'object') continue;
+
+    const nextModelIds = [];
+    for (const modelId of uniqueStringArray(group.modelIds)) {
+      if (allowed && !allowed.has(modelId)) continue;
+      if (seenModelIds.has(modelId)) continue;
+      seenModelIds.add(modelId);
+      nextModelIds.push(modelId);
+    }
+
+    if (nextModelIds.length === 0) continue;
+
+    normalized.push({
+      ...group,
+      id: typeof group.id === 'string' && group.id.trim() ? group.id : makeId('grp'),
+      name: typeof group.name === 'string' && group.name.trim() ? group.name.trim() : 'Untitled group',
+      description: typeof group.description === 'string' ? group.description : '',
+      modelIds: nextModelIds,
+    });
+  }
+
+  return normalized;
+}
+
+function flattenCollectionModelIds(modelIds, groups = []) {
+  return uniqueStringArray([
+    ...uniqueStringArray(modelIds),
+    ...normalizeCollectionGroups(groups).flatMap(group => group.modelIds),
+  ]);
+}
+
+function reconcileCollectionGroups(groups, allowedModelIds) {
+  const allowed = uniqueStringArray(allowedModelIds);
+  return normalizeCollectionGroups(groups, allowed);
+}
+
+function normalizeStoredCollection(collection) {
+  if (!collection || typeof collection !== 'object') return collection;
+  const normalizedGroups = normalizeCollectionGroups(collection.groups);
+  return {
+    ...collection,
+    modelIds: flattenCollectionModelIds(collection.modelIds, normalizedGroups),
+    groups: normalizedGroups,
+  };
+}
+
 function loadCollections() {
   try {
     if (!fs.existsSync(collectionsFilePath)) return [];
     const raw = fs.readFileSync(collectionsFilePath, 'utf8');
     if (!raw || raw.trim() === '') return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : (parsed && Array.isArray(parsed.collections) ? parsed.collections : []);
+    const collections = Array.isArray(parsed) ? parsed : (parsed && Array.isArray(parsed.collections) ? parsed.collections : []);
+    return collections.map(normalizeStoredCollection);
   } catch (e) {
     console.warn('Failed to load collections.json:', e);
     return [];
@@ -262,16 +322,20 @@ app.get('/api/collections', (req, res) => {
 // Create or update a collection
 app.post('/api/collections', (req, res) => {
   try {
-    const { id, name, description = '', modelIds = [], coverModelId, category = '', tags = [], images = [] } = req.body || {};
+    const { id, name, description = '', modelIds = [], coverModelId, category = '', tags = [], images = [], groups } = req.body || {};
     if (!name || typeof name !== 'string' || name.trim() === '') {
       return res.status(400).json({ success: false, error: 'Name is required' });
     }
     if (!Array.isArray(modelIds)) {
       return res.status(400).json({ success: false, error: 'modelIds must be an array' });
     }
+    if (groups !== undefined && !Array.isArray(groups)) {
+      return res.status(400).json({ success: false, error: 'groups must be an array when provided' });
+    }
 
     const now = new Date().toISOString();
-    const normalizedIds = Array.from(new Set(modelIds.filter(x => typeof x === 'string' && x.trim() !== '')));
+    const requestedIds = uniqueStringArray(modelIds);
+    const hasGroupsPayload = Object.prototype.hasOwnProperty.call(req.body || {}, 'groups');
 
     const cols = loadCollections();
     let result;
@@ -281,7 +345,11 @@ app.post('/api/collections', (req, res) => {
         return res.status(404).json({ success: false, error: 'Collection not found' });
       }
       const prev = cols[idx] || { modelIds: [] };
-      const updated = { ...prev, name, description, modelIds: normalizedIds, coverModelId, lastModified: now };
+      const nextGroups = hasGroupsPayload
+        ? normalizeCollectionGroups(groups)
+        : reconcileCollectionGroups(prev.groups, requestedIds);
+      const normalizedIds = flattenCollectionModelIds(requestedIds, nextGroups);
+      const updated = { ...prev, name, description, modelIds: normalizedIds, coverModelId, groups: nextGroups, lastModified: now };
       if (typeof category === 'string') updated.category = category;
       if (Array.isArray(tags)) updated.tags = Array.from(new Set(tags.filter(t => typeof t === 'string')));
       if (Array.isArray(images)) updated.images = images.filter(s => typeof s === 'string');
@@ -338,7 +406,9 @@ app.post('/api/collections', (req, res) => {
       try { reconcileHiddenFlags(); } catch {}
       result = updated;
     } else {
-      const newCol = { id: makeId(), name, description, modelIds: normalizedIds, coverModelId, category, tags: Array.isArray(tags) ? Array.from(new Set(tags.filter(t => typeof t === 'string'))) : [], images: Array.isArray(images) ? images.filter(s => typeof s === 'string') : [], created: now, lastModified: now };
+      const normalizedGroups = normalizeCollectionGroups(groups);
+      const normalizedIds = flattenCollectionModelIds(requestedIds, normalizedGroups);
+      const newCol = { id: makeId(), name, description, modelIds: normalizedIds, groups: normalizedGroups, coverModelId, category, tags: Array.isArray(tags) ? Array.from(new Set(tags.filter(t => typeof t === 'string'))) : [], images: Array.isArray(images) ? images.filter(s => typeof s === 'string') : [], created: now, lastModified: now };
       cols.push(newCol);
       if (!saveCollections(cols)) return res.status(500).json({ success: false, error: 'Failed to save collection' });
       // Newly created collection: mark included models as hidden in their munchie files

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { FilterSidebar } from "./components/FilterSidebar";
 import { ModelGrid } from "./components/ModelGrid";
 import { ModelDetailsDrawer } from "./components/ModelDetailsDrawer";
 import { BulkEditDrawer } from "./components/BulkEditDrawer";
+import { CollectionCoverCollage } from "./components/CollectionCoverCollage";
+import CollectionEditDrawer from "./components/CollectionEditDrawer";
 import { DonationDialog } from "./components/DonationDialog";
 import { SettingsPage } from "./components/SettingsPage";
 import { DemoPage } from "./components/DemoPage";
@@ -17,7 +19,7 @@ import { ConfigManager } from "./utils/configManager";
 import * as pkg from '../package.json';
 import { applyFiltersToModels, FilterState } from "./utils/filterUtils";
 import { sortModels, sortCollections, SortKey } from "./utils/sortUtils";
-import { Menu, Palette, RefreshCw, Heart, FileCheck, Files, Box, Upload, List, ArrowLeft } from "lucide-react";
+import { Menu, Palette, RefreshCw, Heart, FileCheck, Files, Box, Upload, List, ArrowLeft, Plus } from "lucide-react";
 import ModelUploadDialog from "./components/ModelUploadDialog";
 import { Button } from "./components/ui/button";
 import {
@@ -95,8 +97,8 @@ function AppContent() {
   // Track where to return when leaving a collection view
   const [collectionReturnView, setCollectionReturnView] = useState<ViewType>('models');
   // Track last applied filters so we can reapply when navigating back from a collection or after refresh
-  const [lastFilters, setLastFilters] = useState<{ search: string; category: string; printStatus: string; license: string; fileType: string; tags: string[]; showHidden: boolean; showMissingImages: boolean; sortBy?: string }>(
-    { search: '', category: 'all', printStatus: 'all', license: 'all', fileType: 'all', tags: [], showHidden: false, showMissingImages: false, sortBy: 'none' }
+  const [lastFilters, setLastFilters] = useState<{ search: string; category: string; printStatus: string; license: string; fileType: string; collectionId?: string; tags: string[]; showHidden: boolean; showMissingImages: boolean; sortBy?: string }>(
+    { search: '', category: 'all', printStatus: 'all', license: 'all', fileType: 'all', collectionId: 'all', tags: [], showHidden: false, showMissingImages: false, sortBy: 'none' }
   );
   // Force sidebar to re-mount to reset its internal filter UI when switching contexts
   const [sidebarResetKey, setSidebarResetKey] = useState(0);
@@ -115,6 +117,21 @@ function AppContent() {
     }
     return models;
   }, [models, activeCollection]);
+
+  const applyCollectionScopedFilters = (
+    modelsToFilter: Model[],
+    filters: FilterState & { collectionId?: string }
+  ) => {
+    let scopedModels = modelsToFilter;
+    const selectedCollectionId = filters.collectionId || 'all';
+    if (selectedCollectionId !== 'all') {
+      const selectedCollection = collections.find((collection) => collection.id === selectedCollectionId);
+      const allowedIds = new Set(selectedCollection?.modelIds || []);
+      scopedModels = scopedModels.filter((model) => allowedIds.has(model.id));
+    }
+
+    return applyFiltersToModels(scopedModels, filters);
+  };
   
   // Delete file type selection state
   const [includeThreeMfFiles, setIncludeThreeMfFiles] = useState(false);
@@ -195,13 +212,14 @@ function AppContent() {
           printStatus: defaultFilters.defaultPrintStatus,
           license: defaultFilters.defaultLicense,
           fileType: 'all',
+          collectionId: 'all',
           tags: [] as string[],
           showHidden: false,
           showMissingImages: false,
           sortBy: defaultFilters.defaultSortBy || 'none',
         };
   
-  const visibleModels = applyFiltersToModels(loadedModels, initialFilterState as FilterState);
+  const visibleModels = applyCollectionScopedFilters(loadedModels, initialFilterState as FilterState & { collectionId?: string });
   setFilteredModels(visibleModels);
   // Remember the initial filters for later reapplication
   setLastFilters(initialFilterState);
@@ -619,6 +637,7 @@ function AppContent() {
     printStatus: string;
     license: string;
     fileType: string;
+    collectionId?: string;
     tags: string[];
     showHidden: boolean;
     showMissingImages: boolean;
@@ -663,12 +682,13 @@ function AppContent() {
       printStatus: filters.printStatus,
       license: filters.license,
       fileType: filters.fileType,
+      collectionId: filters.collectionId,
       tags: filters.tags,
       showHidden: filters.showHidden,
       showMissingImages: filters.showMissingImages,
     };
     
-    const filtered = applyFiltersToModels(baseModels, filterState);
+    const filtered = applyCollectionScopedFilters(baseModels, filterState);
 
     // Apply sorting via utility
     const sortKey = (filters.sortBy || 'none') as SortKey;
@@ -715,14 +735,14 @@ function AppContent() {
           ...lastFilters,
           fileType: lastFilters.fileType?.toLowerCase() === 'collections' ? 'all' : lastFilters.fileType,
         } as any as FilterState;
-        const filtered = applyFiltersToModels(base, filtersForCollection);
+        const filtered = applyCollectionScopedFilters(base, filtersForCollection as FilterState & { collectionId?: string });
         const sorted = sortModels(filtered as any[], (lastFilters.sortBy as SortKey) || 'none');
         setFilteredModels(sorted);
       } else {
         if ((lastFilters.fileType || '').toLowerCase() === 'collections') {
           setFilteredModels([]);
         } else {
-          const filtered = applyFiltersToModels(updatedModels, lastFilters as FilterState);
+          const filtered = applyCollectionScopedFilters(updatedModels, lastFilters as FilterState & { collectionId?: string });
           const sorted = sortModels(filtered as any[], (lastFilters.sortBy as SortKey) || 'none');
           setFilteredModels(sorted);
         }
@@ -802,6 +822,7 @@ function AppContent() {
 
   // Upload dialog state
   const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
+  const [isCreateEmptyCollectionOpen, setIsCreateEmptyCollectionOpen] = useState(false);
 
   const openSettingsOnTab = (tab: string, action?: { type: 'hash-check' | 'generate'; fileType: '3mf' | 'stl' }) => {
     setSettingsInitialTab(tab);
@@ -852,6 +873,7 @@ function AppContent() {
   const refreshCollections = async () => {
     try {
       const r = await fetch('/api/collections');
+      let resolvedActiveCollection = activeCollection;
       if (r.ok) {
         const data = await r.json();
         if (data && data.success && Array.isArray(data.collections)) {
@@ -859,7 +881,10 @@ function AppContent() {
           // Keep activeCollection in sync with latest modelIds
           if (activeCollection) {
             const updatedActive = data.collections.find((c: any) => c.id === activeCollection.id);
-            if (updatedActive) setActiveCollection(updatedActive);
+            if (updatedActive) {
+              resolvedActiveCollection = updatedActive;
+              setActiveCollection(updatedActive);
+            }
           }
         }
       }
@@ -870,8 +895,8 @@ function AppContent() {
           const updatedModels = await resp.json() as Model[];
           setModels(updatedModels);
           // Reapply filters based on current view
-          if (currentView === 'collection-view' && activeCollection) {
-            const setIds = new Set(activeCollection.modelIds || []);
+          if (currentView === 'collection-view' && resolvedActiveCollection) {
+            const setIds = new Set(resolvedActiveCollection.modelIds || []);
             let base = updatedModels.filter(m => setIds.has(m.id));
             const filtersForCollection = {
               ...lastFilters,
@@ -879,14 +904,14 @@ function AppContent() {
               // In collection view, default to including hidden unless explicitly toggled by user later
               showHidden: true,
             } as any as FilterState;
-            const filtered = applyFiltersToModels(base, filtersForCollection);
+            const filtered = applyCollectionScopedFilters(base, filtersForCollection as FilterState & { collectionId?: string });
             const sorted = sortModels(filtered as any[], (lastFilters.sortBy as SortKey) || 'none');
             setFilteredModels(sorted);
           } else {
             if ((lastFilters.fileType || '').toLowerCase() === 'collections') {
               setFilteredModels([]);
             } else {
-              const filtered = applyFiltersToModels(updatedModels, lastFilters as FilterState);
+              const filtered = applyCollectionScopedFilters(updatedModels, lastFilters as FilterState & { collectionId?: string });
               const sorted = sortModels(filtered as any[], (lastFilters.sortBy as SortKey) || 'none');
               setFilteredModels(sorted);
             }
@@ -954,6 +979,10 @@ function AppContent() {
     }
 
     let filteredList = collections.slice();
+    const selectedCollectionId = filters.collectionId || 'all';
+    if (selectedCollectionId !== 'all') {
+      filteredList = filteredList.filter((collection) => collection.id === selectedCollectionId);
+    }
 
     const searchTerm = (filters.search || '').trim().toLowerCase();
     if (searchTerm) {
@@ -1051,20 +1080,23 @@ function AppContent() {
             onClose={() => setIsSidebarOpen(false)}
             onSettingsClick={handleSettingsClick}
             categories={sortedCategories}
+            collections={collections}
+            showCollectionFilter={currentView !== 'collection-view'}
             models={(currentView === 'collection-view' && activeCollection)
               ? collectionBaseModels
               : models}
             initialFilters={{
-              search: '',
-              category: appConfig?.filters?.defaultCategory || 'all',
-              printStatus: appConfig?.filters?.defaultPrintStatus || 'all',
-              license: appConfig?.filters?.defaultLicense || 'all',
-              fileType: 'all',
-              tags: [],
+              search: lastFilters.search ?? '',
+              category: lastFilters.category || appConfig?.filters?.defaultCategory || 'all',
+              printStatus: lastFilters.printStatus || appConfig?.filters?.defaultPrintStatus || 'all',
+              license: lastFilters.license || appConfig?.filters?.defaultLicense || 'all',
+              fileType: lastFilters.fileType || 'all',
+              collectionId: currentView === 'collection-view' ? 'all' : (lastFilters.collectionId || 'all'),
+              tags: lastFilters.tags || [],
               // In collection view, default to showing hidden items so the collection shows everything
-              showHidden: currentView === 'collection-view',
-              showMissingImages: false,
-              sortBy: appConfig?.filters?.defaultSortBy || 'none',
+              showHidden: currentView === 'collection-view' ? true : !!lastFilters.showHidden,
+              showMissingImages: !!lastFilters.showMissingImages,
+              sortBy: lastFilters.sortBy || appConfig?.filters?.defaultSortBy || 'none',
             }}
           />
         )}
@@ -1193,6 +1225,7 @@ function AppContent() {
           {currentView === 'models' ? (
             <ModelGrid 
               models={filteredModels} 
+              collectionModels={models}
               collections={sortCollections(collectionsForDisplay, currentSortBy)}
               sortBy={currentSortBy}
               onModelClick={handleModelClick}
@@ -1250,25 +1283,33 @@ function AppContent() {
                   </Button>
                   <div className="font-semibold">Collections</div>
                 </div>
-                <Button variant="ghost" size="sm" onClick={refreshCollections} title="Refresh collections">
-                  <RefreshCw className="h-4 w-4" />
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="sm" onClick={() => setIsCreateEmptyCollectionOpen(true)} className="gap-2">
+                    <Plus className="h-4 w-4" />
+                    New Collection
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={refreshCollections} title="Refresh collections">
+                    <RefreshCw className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
               <div className="p-4 lg:p-6">
-                {collections.length === 0 ? (
-                  <div className="text-sm text-muted-foreground">No collections yet. Select some models and create one from the selection.</div>
+                {collectionsForDisplay.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">
+                    {collections.length === 0
+                      ? 'No collections yet. Create one here, or select some models and create one from the selection.'
+                      : 'No collections match the current filters.'}
+                  </div>
                 ) : (
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {sortCollections(collections, currentSortBy).map(c => (
+                    {sortCollections(collectionsForDisplay, currentSortBy).map(c => (
                       <button key={c.id} onClick={() => openCollection(c)} className="p-4 text-left rounded-lg border bg-card hover:bg-accent/50 transition-colors">
                         <div className="flex items-center gap-3">
-                          <div className="relative w-16 h-12 rounded overflow-hidden bg-muted/40 flex-shrink-0">
-                            {Array.isArray(c.images) && c.images.length > 0 ? (
-                              <img src={c.images[0]} alt="" className="absolute inset-0 w-full h-full object-cover" />
-                            ) : (
-                              <div className="w-full h-full" />
-                            )}
-                          </div>
+                          <CollectionCoverCollage
+                            collection={c}
+                            models={models}
+                            className="relative w-16 h-12 rounded overflow-hidden flex-shrink-0"
+                          />
                           <div className="min-w-0 flex-1">
                             <div className="font-medium truncate">{c.name}</div>
                             <div className="text-xs text-muted-foreground mt-1">{(c.modelIds || []).length} items</div>
@@ -1294,7 +1335,7 @@ function AppContent() {
                   if ((lastFilters.fileType || '').toLowerCase() === 'collections') {
                     setFilteredModels([]);
                   } else {
-                    const filtered = applyFiltersToModels(models, lastFilters as FilterState);
+                    const filtered = applyCollectionScopedFilters(models, lastFilters as FilterState & { collectionId?: string });
                     const sorted = sortModels(filtered as any[], (lastFilters.sortBy as SortKey) || 'none');
                     setFilteredModels(sorted);
                   }
@@ -1459,7 +1500,18 @@ function AppContent() {
       <ModelUploadDialog
         isOpen={isUploadDialogOpen}
         onClose={() => setIsUploadDialogOpen(false)}
-        onUploaded={() => { handleRefreshModels(); }}
+        onUploaded={refreshCollections}
+      />
+      <CollectionEditDrawer
+        open={isCreateEmptyCollectionOpen}
+        onOpenChange={setIsCreateEmptyCollectionOpen}
+        collection={null}
+        categories={sortedCategories}
+        initialModelIds={[]}
+        onSaved={async () => {
+          setIsCreateEmptyCollectionOpen(false);
+          await refreshCollections();
+        }}
       />
     </div>
     </TagsProvider>

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Folder, ChevronRight, MoreVertical, Pencil, Trash2 } from "lucide-react";
+import { ChevronRight, MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { Card, CardContent, CardFooter, CardHeader } from "./ui/card";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -10,16 +10,19 @@ import type { Category } from "../types/category";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 import { ConfigManager } from "../utils/configManager";
 import { getLabel } from "../constants/labels";
+import type { Model } from "../types/model";
+import { CollectionCoverCollage } from "./CollectionCoverCollage";
 
 export interface CollectionCardProps {
   collection: Collection;
   categories: Category[];
+  models?: Model[];
   onOpen: (id: string) => void;
   onChanged?: () => void; // called after edit save
   onDeleted?: (id: string) => void;
 }
 
-export function CollectionCard({ collection, categories, onOpen, onChanged, onDeleted }: CollectionCardProps) {
+export function CollectionCard({ collection, categories, models = [], onOpen, onChanged, onDeleted }: CollectionCardProps) {
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
@@ -48,7 +51,6 @@ export function CollectionCard({ collection, categories, onOpen, onChanged, onDe
   const modelCount = collection?.modelIds ? collection.modelIds.length : 0;
   const groupCount = Array.isArray(collection?.groups) ? collection.groups.length : 0;
   const collectionId = collection?.id;
-
   return (
     <Card
       className="flex flex-col cursor-pointer transition-all hover:shadow-lg hover:-translate-y-1"
@@ -57,17 +59,12 @@ export function CollectionCard({ collection, categories, onOpen, onChanged, onDe
       }}
     >
       <CardHeader className="p-0">
-        <div className="relative aspect-[4/3] overflow-hidden rounded-t-lg bg-muted/40 flex items-center justify-center">
-          {Array.isArray(collection?.images) && collection!.images!.length > 0 ? (
-            <img
-              src={collection!.images![0]}
-              alt={collection?.name || 'Collection cover'}
-              className="absolute inset-0 w-full h-full object-cover"
-              draggable={false}
-            />
-          ) : (
-            <Folder className="w-14 h-14 text-primary/80" />
-          )}
+        <div className="relative aspect-[4/3] overflow-hidden rounded-t-lg">
+          <CollectionCoverCollage
+            collection={collection}
+            models={models}
+            className="absolute inset-0"
+          />
           <div className="absolute top-3 left-3">
             <Badge variant="secondary">Collection</Badge>
           </div>

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -46,6 +46,7 @@ export function CollectionCard({ collection, categories, onOpen, onChanged, onDe
 
   // Runtime guard: if a malformed item slips through, avoid crashing the UI
   const modelCount = collection?.modelIds ? collection.modelIds.length : 0;
+  const groupCount = Array.isArray(collection?.groups) ? collection.groups.length : 0;
   const collectionId = collection?.id;
 
   return (
@@ -149,7 +150,9 @@ export function CollectionCard({ collection, categories, onOpen, onChanged, onDe
       </CardContent>
       <CardFooter className="p-4 pt-0 mt-auto">
         <Button variant="outline" size="sm" className="w-full justify-between">
-          {`View ${modelCount} model${modelCount !== 1 ? 's' : ''}`}
+          {groupCount > 0
+            ? `View ${modelCount} model${modelCount !== 1 ? 's' : ''}, ${groupCount} group${groupCount !== 1 ? 's' : ''}`
+            : `View ${modelCount} model${modelCount !== 1 ? 's' : ''}`}
           <ChevronRight className="h-4 w-4" />
         </Button>
       </CardFooter>

--- a/src/components/CollectionCoverCollage.tsx
+++ b/src/components/CollectionCoverCollage.tsx
@@ -1,0 +1,52 @@
+import { Folder } from "lucide-react";
+import type { Collection } from "../types/collection";
+import type { Model } from "../types/model";
+import { getCollectionCoverImages } from "../utils/collectionCoverUtils";
+
+interface CollectionCoverCollageProps {
+  collection: Collection;
+  models?: Model[];
+  className?: string;
+  imageClassName?: string;
+}
+
+export function CollectionCoverCollage({
+  collection,
+  models = [],
+  className = "",
+  imageClassName = "",
+}: CollectionCoverCollageProps) {
+  const previewImages = getCollectionCoverImages(collection, models, 4);
+
+  if (previewImages.length === 0) {
+    return (
+      <div className={`bg-muted/40 flex items-center justify-center ${className}`}>
+        <Folder className="w-10 h-10 text-primary/80" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`bg-muted/30 p-1 ${className}`}>
+      <div className="grid w-full h-full grid-cols-2 grid-rows-2 gap-1">
+        {Array.from({ length: 4 }, (_, index) => {
+          const src = previewImages[index];
+          return (
+            <div key={index} className="overflow-hidden rounded-sm bg-muted/40">
+              {src ? (
+                <img
+                  src={src}
+                  alt=""
+                  className={`w-full h-full object-cover ${imageClassName}`}
+                  draggable={false}
+                />
+              ) : (
+                <div className="w-full h-full bg-muted/50" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CollectionEditDrawer.tsx
+++ b/src/components/CollectionEditDrawer.tsx
@@ -9,6 +9,7 @@ import TagsInput from './TagsInput';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from './ui/select';
 import type { Collection } from '../types/collection';
 import type { Category } from '../types/category';
+import { getValidCollectionCoverId } from '../utils/collectionCoverUtils';
 
 interface Props {
   open: boolean;
@@ -112,7 +113,7 @@ export default function CollectionEditDrawer({ open, onOpenChange, collection, c
           category: (existing as any).category || '',
           tags: (existing as any).tags || [],
           images: (existing as any).images || [],
-          coverModelId: (existing as any).coverModelId,
+          coverModelId: getValidCollectionCoverId(nextIds, (existing as any).coverModelId),
         };
       } else {
         // Create new or update current collection (edit)
@@ -126,9 +127,10 @@ export default function CollectionEditDrawer({ open, onOpenChange, collection, c
         if (isEdit) {
           payload.id = collection!.id;
           payload.modelIds = collection!.modelIds;
-          payload.coverModelId = collection!.coverModelId;
+          payload.coverModelId = getValidCollectionCoverId(collection!.modelIds, collection!.coverModelId);
         } else {
           payload.modelIds = Array.isArray(initialModelIds) ? initialModelIds : [];
+          payload.coverModelId = getValidCollectionCoverId(payload.modelIds);
         }
       }
 
@@ -165,7 +167,7 @@ export default function CollectionEditDrawer({ open, onOpenChange, collection, c
         category: (removalTarget as any).category || '',
         tags: (removalTarget as any).tags || [],
         images: (removalTarget as any).images || [],
-        coverModelId: (removalTarget as any).coverModelId,
+        coverModelId: getValidCollectionCoverId(remainingIds, (removalTarget as any).coverModelId),
       };
 
       const resp = await fetch('/api/collections', {

--- a/src/components/CollectionGrid.tsx
+++ b/src/components/CollectionGrid.tsx
@@ -1,14 +1,20 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { MouseEvent } from 'react';
-import { Model } from '../types/model';
-import type { Collection } from '../types/collection';
+import { ArrowLeft, ChevronDown, MoreVertical, Pencil, Trash2 } from 'lucide-react';
+import type { Model } from '../types/model';
+import type { Collection, CollectionGroup } from '../types/collection';
 import { ModelCard } from './ModelCard';
 import { ScrollArea } from './ui/scroll-area';
 import { Button } from './ui/button';
-import { ArrowLeft } from 'lucide-react';
+import { Badge } from './ui/badge';
 import type { AppConfig } from '../types/config';
-import CollectionEditDrawer from './CollectionEditDrawer';
 import { SelectionModeControls } from './SelectionModeControls';
+import { Collapsible, CollapsibleContent } from './ui/collapsible';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from './ui/alert-dialog';
+import { ImageWithFallback } from './ImageWithFallback';
+import { resolveModelThumbnail } from '../utils/thumbnailUtils';
+import CollectionGroupDrawer from './CollectionGroupDrawer';
 
 interface CollectionGridProps {
   name: string;
@@ -28,6 +34,22 @@ interface CollectionGridProps {
   onBulkDelete?: () => void | Promise<void>;
   onCollectionChanged?: () => void;
 }
+
+interface VisibleGroup extends CollectionGroup {
+  visibleModels: Model[];
+}
+
+const buildCollectionPayload = (collection: Collection, groups: CollectionGroup[]) => ({
+  id: collection.id,
+  name: collection.name,
+  description: collection.description || '',
+  modelIds: collection.modelIds || [],
+  groups,
+  category: collection.category || '',
+  tags: collection.tags || [],
+  images: collection.images || [],
+  coverModelId: collection.coverModelId,
+});
 
 export default function CollectionGrid({
   name,
@@ -49,21 +71,60 @@ export default function CollectionGrid({
 }: CollectionGridProps) {
   const items = useMemo(() => {
     const set = new Set(modelIds);
-    return models.filter(m => set.has(m.id));
+    return models.filter((model) => set.has(model.id));
   }, [modelIds, models]);
 
   const modelIndexMap = useMemo(() => {
     const map = new Map<string, number>();
-    models.forEach((m, idx) => map.set(m.id, idx));
+    models.forEach((model, index) => map.set(model.id, index));
     return map;
   }, [models]);
 
-  const [isCreateCollectionOpen, setIsCreateCollectionOpen] = useState(false);
+  const visibleGroups = useMemo<VisibleGroup[]>(() => {
+    const groups = Array.isArray(activeCollection?.groups) ? activeCollection.groups : [];
+    const modelMap = new Map(items.map((model) => [model.id, model]));
 
-  const handleModelInteraction = (e: MouseEvent, model: Model, fallbackIndex: number) => {
+    return groups
+      .map((group) => ({
+        ...group,
+        visibleModels: (group.modelIds || [])
+          .map((modelId) => modelMap.get(modelId))
+          .filter(Boolean) as Model[],
+      }))
+      .filter((group) => group.visibleModels.length > 0);
+  }, [activeCollection?.groups, items]);
+
+  const groupedVisibleIds = useMemo(() => {
+    const set = new Set<string>();
+    visibleGroups.forEach((group) => {
+      group.visibleModels.forEach((model) => set.add(model.id));
+    });
+    return set;
+  }, [visibleGroups]);
+
+  const ungroupedItems = useMemo(
+    () => items.filter((model) => !groupedVisibleIds.has(model.id)),
+    [groupedVisibleIds, items]
+  );
+
+  const [isGroupDrawerOpen, setIsGroupDrawerOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<CollectionGroup | null>(null);
+  const [groupToRemove, setGroupToRemove] = useState<CollectionGroup | null>(null);
+  const [isUngrouping, setIsUngrouping] = useState(false);
+  const [expandedGroupIds, setExpandedGroupIds] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setIsGroupDrawerOpen(false);
+    setEditingGroup(null);
+    setGroupToRemove(null);
+    setIsUngrouping(false);
+    setExpandedGroupIds({});
+  }, [activeCollection?.id]);
+
+  const handleModelInteraction = (event: MouseEvent, model: Model, fallbackIndex: number) => {
     const index = modelIndexMap.get(model.id) ?? fallbackIndex;
     if (isSelectionMode && onModelSelection) {
-      onModelSelection(model.id, { shiftKey: e.shiftKey, index });
+      onModelSelection(model.id, { shiftKey: event.shiftKey, index });
     } else {
       onModelClick(model);
     }
@@ -73,10 +134,10 @@ export default function CollectionGrid({
 
   const handleBulkDeleteClick = async () => {
     if (!onBulkDelete || selectedCount === 0) return;
-    const res = onBulkDelete();
-    if (res && typeof (res as any).then === 'function') {
+    const result = onBulkDelete();
+    if (result && typeof (result as Promise<void>).then === 'function') {
       try {
-        await res;
+        await result;
       } finally {
         onDeselectAll?.();
         if (isSelectionMode) {
@@ -85,6 +146,42 @@ export default function CollectionGrid({
       }
     }
   };
+
+  const handleGroupSaved = () => {
+    const wasEditing = !!editingGroup?.id;
+    setIsGroupDrawerOpen(false);
+    setEditingGroup(null);
+    onCollectionChanged?.();
+    if (!wasEditing) {
+      onDeselectAll?.();
+      if (isSelectionMode) {
+        onToggleSelectionMode?.();
+      }
+    }
+  };
+
+  const handleUngroup = async () => {
+    if (!activeCollection?.id || !groupToRemove?.id) return;
+    setIsUngrouping(true);
+    try {
+      const nextGroups = (activeCollection.groups || []).filter((group) => group.id !== groupToRemove.id);
+      const resp = await fetch('/api/collections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildCollectionPayload(activeCollection, nextGroups)),
+      });
+      const res = await resp.json();
+      if (!resp.ok || !res.success) throw new Error(res?.error || 'Failed to ungroup');
+      setGroupToRemove(null);
+      onCollectionChanged?.();
+    } catch (error) {
+      console.error('Failed to ungroup collection items:', error);
+    } finally {
+      setIsUngrouping(false);
+    }
+  };
+
+  const totalGroupCount = Array.isArray(activeCollection?.groups) ? activeCollection.groups.length : 0;
 
   return (
     <div className="h-full flex flex-col">
@@ -96,7 +193,10 @@ export default function CollectionGrid({
           </Button>
           <div className="flex flex-col">
             <div className="font-semibold leading-tight">{name}</div>
-            <div className="text-sm text-muted-foreground">{items.length} item{items.length === 1 ? '' : 's'}</div>
+            <div className="text-sm text-muted-foreground">
+              {items.length} item{items.length === 1 ? '' : 's'}
+              {totalGroupCount > 0 ? `, ${totalGroupCount} group${totalGroupCount === 1 ? '' : 's'}` : ''}
+            </div>
           </div>
         </div>
 
@@ -106,55 +206,200 @@ export default function CollectionGrid({
           onEnterSelectionMode={onToggleSelectionMode}
           onExitSelectionMode={onToggleSelectionMode}
           onBulkEdit={onBulkEdit}
-          onCreateCollection={selectedCount > 0 ? () => setIsCreateCollectionOpen(true) : undefined}
+          onCreateCollection={selectedCount > 0 ? () => {
+            setEditingGroup(null);
+            setIsGroupDrawerOpen(true);
+          } : undefined}
+          createActionLabel="Group"
+          createActionTitle="Group selected models"
           onBulkDelete={onBulkDelete ? handleBulkDeleteClick : undefined}
           onSelectAll={onSelectAll}
           onDeselectAll={onDeselectAll}
         />
       </div>
       <ScrollArea className="flex-1 min-h-0">
-        <div className="p-4 lg:p-6 pb-8 lg:pb-12">
+        <div className="p-4 lg:p-6 pb-8 lg:pb-12 space-y-6">
           {items.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <h2 className="font-semibold text-lg">Collection is empty</h2>
               <p className="text-muted-foreground text-sm">Return and add items to this collection.</p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 lg:gap-6">
-              {items.map((model, index) => {
-                const modelIndex = modelIndexMap.get(model.id) ?? index;
-                return (
-                  <ModelCard
-                    key={model.id}
-                    model={model}
-                    onClick={(e) => handleModelInteraction(e, model, modelIndex)}
-                    isSelectionMode={isSelectionMode}
-                    isSelected={selectedModelIds.includes(model.id)}
-                    onSelectionChange={(id, shiftKey) => onModelSelection?.(id, { shiftKey, index: modelIndex })}
-                    config={config || undefined}
-                  />
-                );
-              })}
-            </div>
+            <>
+              {visibleGroups.length > 0 && (
+                <section className="space-y-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h2 className="font-semibold text-lg">Groups</h2>
+                      <p className="text-sm text-muted-foreground">Expand a family to browse its individual variants.</p>
+                    </div>
+                    <Badge variant="secondary">{visibleGroups.length} visible</Badge>
+                  </div>
+
+                  {visibleGroups.map((group) => {
+                    const isExpanded = !!expandedGroupIds[group.id];
+                    const coverModel = group.visibleModels[0];
+                    const visibleCount = group.visibleModels.length;
+                    const totalCount = group.modelIds.length;
+
+                    return (
+                      <Collapsible key={group.id} open={isExpanded} onOpenChange={(open) => setExpandedGroupIds((prev) => ({ ...prev, [group.id]: open }))}>
+                        <div className="rounded-xl border bg-card shadow-sm overflow-hidden">
+                          <div className="flex items-stretch gap-4 p-4">
+                            <button
+                              type="button"
+                              className="flex flex-1 items-stretch gap-4 text-left"
+                              onClick={() => setExpandedGroupIds((prev) => ({ ...prev, [group.id]: !isExpanded }))}
+                            >
+                              <div className="w-24 shrink-0">
+                                <ImageWithFallback
+                                  src={coverModel ? resolveModelThumbnail(coverModel) : ''}
+                                  alt={group.name}
+                                  className="h-24 w-24 rounded-lg border object-cover"
+                                  draggable={false}
+                                />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-start gap-3">
+                                  <div className="min-w-0 flex-1">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                      <h3 className="font-semibold text-lg truncate">{group.name}</h3>
+                                      <Badge variant="outline">Group</Badge>
+                                    </div>
+                                    {group.description && (
+                                      <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{group.description}</p>
+                                    )}
+                                  </div>
+                                  <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                                    <span>{visibleCount === totalCount ? `${totalCount} variants` : `${visibleCount} of ${totalCount} variants`}</span>
+                                    <ChevronDown className={`h-4 w-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
+                                  </div>
+                                </div>
+                              </div>
+                            </button>
+
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="mt-1 h-8 w-8 shrink-0"
+                                  onClick={(event) => event.stopPropagation()}
+                                  title="Group actions"
+                                  aria-label="Group actions"
+                                >
+                                  <MoreVertical className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+                                <DropdownMenuItem onClick={() => { setEditingGroup(group); setIsGroupDrawerOpen(true); }}>
+                                  <Pencil className="h-4 w-4 mr-2" /> Edit group
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() => setGroupToRemove(group)}
+                                  className="text-destructive focus:text-destructive"
+                                >
+                                  <Trash2 className="h-4 w-4 mr-2" /> Ungroup
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
+
+                          <CollapsibleContent>
+                            <div className="border-t px-4 pb-4 pt-4">
+                              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                                {group.visibleModels.map((model, index) => {
+                                  const modelIndex = modelIndexMap.get(model.id) ?? index;
+                                  return (
+                                    <ModelCard
+                                      key={model.id}
+                                      model={model}
+                                      onClick={(event) => handleModelInteraction(event, model, modelIndex)}
+                                      isSelectionMode={isSelectionMode}
+                                      isSelected={selectedModelIds.includes(model.id)}
+                                      onSelectionChange={(id, shiftKey) => onModelSelection?.(id, { shiftKey, index: modelIndex })}
+                                      config={config || undefined}
+                                    />
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          </CollapsibleContent>
+                        </div>
+                      </Collapsible>
+                    );
+                  })}
+                </section>
+              )}
+
+              {ungroupedItems.length > 0 && (
+                <section className="space-y-4">
+                  {visibleGroups.length > 0 && (
+                    <div>
+                      <h2 className="font-semibold text-lg">Ungrouped</h2>
+                      <p className="text-sm text-muted-foreground">Models not assigned to a family still appear individually.</p>
+                    </div>
+                  )}
+
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {ungroupedItems.map((model, index) => {
+                      const modelIndex = modelIndexMap.get(model.id) ?? index;
+                      return (
+                        <ModelCard
+                          key={model.id}
+                          model={model}
+                          onClick={(event) => handleModelInteraction(event, model, modelIndex)}
+                          isSelectionMode={isSelectionMode}
+                          isSelected={selectedModelIds.includes(model.id)}
+                          onSelectionChange={(id, shiftKey) => onModelSelection?.(id, { shiftKey, index: modelIndex })}
+                          config={config || undefined}
+                        />
+                      );
+                    })}
+                  </div>
+                </section>
+              )}
+            </>
           )}
         </div>
       </ScrollArea>
-      <CollectionEditDrawer
-        open={isCreateCollectionOpen}
-        onOpenChange={setIsCreateCollectionOpen}
-        collection={null}
-  categories={config?.categories || []}
-  removalCollection={activeCollection ?? null}
-        initialModelIds={selectedModelIds}
-        onSaved={() => {
-          setIsCreateCollectionOpen(false);
-          onCollectionChanged?.();
-          onDeselectAll?.();
-          if (isSelectionMode) {
-            onToggleSelectionMode?.();
-          }
+      <CollectionGroupDrawer
+        open={isGroupDrawerOpen}
+        onOpenChange={(open) => {
+          setIsGroupDrawerOpen(open);
+          if (!open) setEditingGroup(null);
         }}
+        collection={activeCollection ?? null}
+        selectedModelIds={selectedModelIds}
+        group={editingGroup}
+        onSaved={handleGroupSaved}
       />
+
+      <AlertDialog open={!!groupToRemove} onOpenChange={(open) => { if (!open) setGroupToRemove(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Ungroup these models?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {groupToRemove
+                ? `This removes "${groupToRemove.name}" as a group, but keeps all ${groupToRemove.modelIds.length} model${groupToRemove.modelIds.length === 1 ? '' : 's'} in the collection.`
+                : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isUngrouping}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={async (event) => {
+                event.preventDefault();
+                await handleUngroup();
+              }}
+              disabled={isUngrouping}
+            >
+              {isUngrouping ? 'Ungrouping...' : 'Ungroup'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/CollectionGroupDrawer.tsx
+++ b/src/components/CollectionGroupDrawer.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useState } from 'react';
+import { List, Plus } from 'lucide-react';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from './ui/sheet';
+import { ScrollArea } from './ui/scroll-area';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import type { Collection, CollectionGroup } from '../types/collection';
+
+interface CollectionGroupDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  collection: Collection | null;
+  selectedModelIds?: string[];
+  group?: CollectionGroup | null;
+  onSaved?: (updated: Collection) => void;
+}
+
+const uniqueStringArray = (values: string[] = []) => Array.from(new Set(values.filter(Boolean)));
+
+const buildCollectionPayload = (collection: Collection, groups: CollectionGroup[], modelIds: string[] = collection.modelIds || []) => ({
+  id: collection.id,
+  name: collection.name,
+  description: collection.description || '',
+  modelIds,
+  groups,
+  category: collection.category || '',
+  tags: collection.tags || [],
+  images: collection.images || [],
+  coverModelId: collection.coverModelId,
+});
+
+export default function CollectionGroupDrawer({
+  open,
+  onOpenChange,
+  collection,
+  selectedModelIds = [],
+  group = null,
+  onSaved,
+}: CollectionGroupDrawerProps) {
+  const [createMode, setCreateMode] = useState<'new' | 'existing'>('new');
+  const [selectedExistingId, setSelectedExistingId] = useState('');
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const availableGroups = useMemo(
+    () => (Array.isArray(collection?.groups) ? collection.groups : []),
+    [collection?.groups]
+  );
+
+  const normalizedSelectedIds = useMemo(
+    () => uniqueStringArray(selectedModelIds),
+    [selectedModelIds]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    if (group?.id) {
+      setCreateMode('new');
+      setSelectedExistingId('');
+      setName(group.name || '');
+      setDescription(group.description || '');
+      return;
+    }
+
+    setCreateMode('new');
+    setSelectedExistingId('');
+    setName('');
+    setDescription('');
+  }, [open, group?.id, group?.name, group?.description]);
+
+  const save = async () => {
+    if (!collection?.id) return;
+    if (!group?.id) {
+      if (createMode === 'new' && !name.trim()) return;
+      if (createMode === 'existing' && !selectedExistingId) return;
+    }
+
+    setIsSaving(true);
+    try {
+      const currentGroups = Array.isArray(collection.groups) ? collection.groups : [];
+      let nextGroups: CollectionGroup[] = currentGroups;
+
+      if (group?.id) {
+        nextGroups = currentGroups.map((entry) => (
+          entry.id === group.id
+            ? { ...entry, name: name.trim(), description }
+            : entry
+        ));
+      } else {
+        const selectedIdSet = new Set(normalizedSelectedIds);
+        const strippedGroups = currentGroups
+          .map((entry) => ({
+            ...entry,
+            modelIds: (entry.modelIds || []).filter((modelId) => !selectedIdSet.has(modelId)),
+          }))
+          .filter((entry) => entry.modelIds.length > 0);
+
+        if (createMode === 'existing') {
+          nextGroups = strippedGroups.map((entry) => (
+            entry.id === selectedExistingId
+              ? {
+                  ...entry,
+                  modelIds: uniqueStringArray([...(entry.modelIds || []), ...normalizedSelectedIds]),
+                }
+              : entry
+          ));
+        } else {
+          nextGroups = [
+            ...strippedGroups,
+            {
+              id: '',
+              name: name.trim(),
+              description,
+              modelIds: normalizedSelectedIds,
+            },
+          ];
+        }
+      }
+
+      const resp = await fetch('/api/collections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildCollectionPayload(collection, nextGroups)),
+      });
+      const res = await resp.json();
+      if (!resp.ok || !res.success) throw new Error(res?.error || 'Failed to save group');
+      onSaved?.(res.collection);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Failed to save collection group:', error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const selectedCount = normalizedSelectedIds.length;
+  const isEditing = !!group?.id;
+  const removableIds = normalizedSelectedIds.filter((modelId) => (collection?.modelIds || []).includes(modelId));
+
+  const handleRemoveSelected = async () => {
+    if (!collection?.id || removableIds.length === 0) return;
+    setIsRemoving(true);
+    try {
+      const removableIdSet = new Set(removableIds);
+      const nextGroups = (collection.groups || [])
+        .map((entry) => ({
+          ...entry,
+          modelIds: (entry.modelIds || []).filter((modelId) => !removableIdSet.has(modelId)),
+        }))
+        .filter((entry) => entry.modelIds.length > 0);
+      const remainingIds = (collection.modelIds || []).filter((modelId) => !removableIdSet.has(modelId));
+
+      const resp = await fetch('/api/collections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildCollectionPayload(collection, nextGroups, remainingIds)),
+      });
+      const res = await resp.json();
+      if (!resp.ok || !res.success) throw new Error(res?.error || 'Failed to remove items');
+      onSaved?.(res.collection);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Failed to remove models from collection:', error);
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        className="w-full sm:max-w-lg"
+        blockOverlayInteractions={false}
+        onClick={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <SheetHeader>
+          <SheetTitle>{isEditing ? 'Edit group' : 'Group models'}</SheetTitle>
+          <SheetDescription>
+            {isEditing
+              ? 'Rename this grouped family or adjust its description.'
+              : `Bundle ${selectedCount} selected item${selectedCount === 1 ? '' : 's'} under one expandable group inside this collection.`}
+          </SheetDescription>
+        </SheetHeader>
+
+        <ScrollArea className="h-[calc(100vh-8rem)] pr-2">
+          <div className="space-y-4 p-4">
+            {!isEditing && removableIds.length > 0 && (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-3">
+                <div>
+                  <h3 className="text-sm font-semibold text-destructive">Remove from collection</h3>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Remove {removableIds.length} item{removableIds.length === 1 ? '' : 's'} from "{collection?.name || 'this collection'}".
+                    This only affects the current collection and will not delete any model files.
+                  </p>
+                </div>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="gap-2"
+                  onClick={handleRemoveSelected}
+                  disabled={isRemoving}
+                >
+                  {isRemoving ? 'Removing...' : 'Remove selected from collection'}
+                </Button>
+              </div>
+            )}
+
+            {!isEditing && (
+              <div className="flex items-center justify-between">
+                <div className="font-semibold text-lg text-card-foreground">Choose</div>
+                <div className="flex items-center bg-muted/30 rounded-lg p-1 border">
+                  <Button
+                    variant={createMode === 'new' ? 'default' : 'ghost'}
+                    size="sm"
+                    onClick={() => setCreateMode('new')}
+                    className="gap-2 h-8 px-3"
+                  >
+                    <Plus className="h-4 w-4" />
+                    New
+                  </Button>
+                  <Button
+                    variant={createMode === 'existing' ? 'default' : 'ghost'}
+                    size="sm"
+                    onClick={() => setCreateMode('existing')}
+                    className="gap-2 h-8 px-3"
+                  >
+                    <List className="h-4 w-4" />
+                    Existing
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {!isEditing && createMode === 'existing' && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Existing group</label>
+                <Select value={selectedExistingId} onValueChange={setSelectedExistingId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose a group" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableGroups.map((entry) => (
+                      <SelectItem key={entry.id} value={entry.id}>
+                        {entry.name} ({entry.modelIds.length})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {availableGroups.length === 0 && (
+                  <p className="text-xs text-muted-foreground">No groups yet. Create a new one first.</p>
+                )}
+              </div>
+            )}
+
+            {(isEditing || createMode === 'new') && (
+              <>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Group name</label>
+                  <Input
+                    placeholder="Dragon model"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Description</label>
+                  <Textarea
+                    placeholder="Optional note about the grouped variants"
+                    rows={4}
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                  />
+                </div>
+              </>
+            )}
+
+            <div className="rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+              {isEditing
+                ? `${group?.modelIds.length || 0} model${group?.modelIds.length === 1 ? '' : 's'} currently belong to this group.`
+                : `${selectedCount} selected model${selectedCount === 1 ? '' : 's'} will stay in the collection and become one expandable group.`}
+            </div>
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+              <Button
+                onClick={save}
+                disabled={
+                  isSaving
+                  || isRemoving
+                  || !collection?.id
+                  || (!isEditing && selectedCount === 0)
+                  || (!isEditing && createMode === 'existing' && !selectedExistingId)
+                  || ((isEditing || createMode === 'new') && !name.trim())
+                }
+              >
+                {isSaving ? 'Saving...' : 'Save group'}
+              </Button>
+            </div>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/CollectionGroupDrawer.tsx
+++ b/src/components/CollectionGroupDrawer.tsx
@@ -7,6 +7,7 @@ import { Input } from './ui/input';
 import { Textarea } from './ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import type { Collection, CollectionGroup } from '../types/collection';
+import { getValidCollectionCoverId } from '../utils/collectionCoverUtils';
 
 interface CollectionGroupDrawerProps {
   open: boolean;
@@ -28,7 +29,7 @@ const buildCollectionPayload = (collection: Collection, groups: CollectionGroup[
   category: collection.category || '',
   tags: collection.tags || [],
   images: collection.images || [],
-  coverModelId: collection.coverModelId,
+  coverModelId: getValidCollectionCoverId(modelIds, collection.coverModelId),
 });
 
 export default function CollectionGroupDrawer({

--- a/src/components/CollectionListRow.tsx
+++ b/src/components/CollectionListRow.tsx
@@ -23,6 +23,7 @@ export function CollectionListRow({ collection, categories, onOpen, onChanged, o
 
   const collectionId = collection?.id;
   const modelCount = Array.isArray(collection?.modelIds) ? collection.modelIds.length : 0;
+  const groupCount = Array.isArray(collection?.groups) ? collection.groups.length : 0;
 
   const handleOpen = () => {
     if (collectionId) {
@@ -99,6 +100,7 @@ export function CollectionListRow({ collection, categories, onOpen, onChanged, o
             <div className="flex flex-col items-end gap-2">
               <Badge variant="secondary" className="whitespace-nowrap">
                 {modelCount} item{modelCount === 1 ? "" : "s"}
+                {groupCount > 0 ? `, ${groupCount} group${groupCount === 1 ? "" : "s"}` : ""}
               </Badge>
 
               <DropdownMenu>

--- a/src/components/CollectionListRow.tsx
+++ b/src/components/CollectionListRow.tsx
@@ -5,26 +5,27 @@ import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 import CollectionEditDrawer from "./CollectionEditDrawer";
-import { ImageWithFallback } from "./ImageWithFallback";
 import type { Collection } from "../types/collection";
 import type { Category } from "../types/category";
+import type { Model } from "../types/model";
+import { CollectionCoverCollage } from "./CollectionCoverCollage";
 
 interface CollectionListRowProps {
   collection: Collection;
   categories: Category[];
+  models?: Model[];
   onOpen: (id: string) => void;
   onChanged?: () => void;
   onDeleted?: (id: string) => void;
 }
 
-export function CollectionListRow({ collection, categories, onOpen, onChanged, onDeleted }: CollectionListRowProps) {
+export function CollectionListRow({ collection, categories, models = [], onOpen, onChanged, onDeleted }: CollectionListRowProps) {
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   const collectionId = collection?.id;
   const modelCount = Array.isArray(collection?.modelIds) ? collection.modelIds.length : 0;
   const groupCount = Array.isArray(collection?.groups) ? collection.groups.length : 0;
-
   const handleOpen = () => {
     if (collectionId) {
       onOpen(collectionId);
@@ -65,11 +66,10 @@ export function CollectionListRow({ collection, categories, onOpen, onChanged, o
       >
         <div className="flex-shrink-0 pl-1">
           <div className="relative">
-            <ImageWithFallback
-              src={collection?.images && collection.images.length > 0 ? collection.images[0] : ""}
-              alt={collection?.name || "Collection image"}
-              className="w-20 h-20 object-cover rounded-lg border group-hover:border-primary/30 transition-colors"
-              draggable={false}
+            <CollectionCoverCollage
+              collection={collection}
+              models={models}
+              className="w-20 h-20 rounded-lg border group-hover:border-primary/30 transition-colors overflow-hidden"
             />
             <Badge variant="secondary" className="absolute top-2 left-2 text-xs pointer-events-none">
               Collection

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Search, Filter, Layers, X, Settings, FileText, Eye, CircleCheckBig, FileBox, Tag } from "lucide-react";
+import { Search, Filter, Layers, X, Settings, FileText, Eye, CircleCheckBig, FileBox, Tag, List } from "lucide-react";
 import * as LucideIcons from 'lucide-react';
 import { Input } from "./ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
@@ -9,6 +9,7 @@ import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
 import { Category } from "../types/category";
 import { Model } from "../types/model";
+import type { Collection } from "../types/collection";
 import { ScrollArea } from "./ui/scroll-area";
 
 interface FilterSidebarProps {
@@ -18,6 +19,7 @@ interface FilterSidebarProps {
     printStatus: string;
     license: string;
     fileType: string;
+    collectionId?: string;
     tags: string[];
     showHidden: boolean;
     showMissingImages: boolean;
@@ -31,12 +33,15 @@ interface FilterSidebarProps {
   onSettingsClick: () => void;
   categories: Category[];
   models: Model[];
+  collections?: Collection[];
+  showCollectionFilter?: boolean;
   initialFilters?: {
     search: string;
     category: string;
     printStatus: string;
     license: string;
     fileType: string;
+    collectionId?: string;
     tags: string[];
     showHidden: boolean;
     showMissingImages: boolean;
@@ -60,7 +65,9 @@ export function FilterSidebar({
   onClose,
   onSettingsClick,
   categories,
-  models
+  models,
+  collections = [],
+  showCollectionFilter = true
   , initialFilters
 }: FilterSidebarProps) {
   const TAG_DISPLAY_LIMIT = 25;
@@ -102,6 +109,7 @@ export function FilterSidebar({
   const [selectedPrintStatus, setSelectedPrintStatus] = useState(initialFilters?.printStatus ?? "all");
   const [selectedLicense, setSelectedLicense] = useState(initialFilters?.license ?? "all");
   const [selectedFileType, setSelectedFileType] = useState(initialFilters?.fileType ?? "all");
+  const [selectedCollectionId, setSelectedCollectionId] = useState(initialFilters?.collectionId ?? "all");
   const [selectedTags, setSelectedTags] = useState<string[]>(initialFilters?.tags ?? []);
   const [showHidden, setShowHidden] = useState(initialFilters?.showHidden ?? false);
   const [showMissingImages, setShowMissingImages] = useState(initialFilters?.showMissingImages ?? false);
@@ -147,6 +155,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -165,6 +174,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -182,6 +192,7 @@ export function FilterSidebar({
       printStatus: value,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -197,6 +208,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: value,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -212,6 +224,23 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: value,
+      collectionId: selectedCollectionId,
+      tags: selectedTags,
+      showHidden: showHidden,
+      showMissingImages: showMissingImages,
+      sortBy: selectedSort,
+    });
+  };
+
+  const handleCollectionChange = (value: string) => {
+    setSelectedCollectionId(value);
+    onFilterChange({
+      search: searchTerm,
+      category: selectedCategory,
+      printStatus: selectedPrintStatus,
+      license: selectedLicense,
+      fileType: selectedFileType,
+      collectionId: value,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -227,6 +256,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -248,6 +278,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: newSelectedTags,
       showHidden: showHidden,
       showMissingImages: showMissingImages,
@@ -263,6 +294,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: checked,
       showMissingImages: showMissingImages,
@@ -278,6 +310,7 @@ export function FilterSidebar({
       printStatus: selectedPrintStatus,
       license: selectedLicense,
       fileType: selectedFileType,
+      collectionId: selectedCollectionId,
       tags: selectedTags,
       showHidden: showHidden,
       showMissingImages: checked,
@@ -291,6 +324,7 @@ export function FilterSidebar({
     setSelectedPrintStatus("all");
     setSelectedLicense("all");
     setSelectedFileType("all");
+    setSelectedCollectionId("all");
     setSelectedTags([]);
     setShowHidden(false);
     setShowMissingImages(false);
@@ -302,6 +336,7 @@ export function FilterSidebar({
       printStatus: "all",
       license: "all",
       fileType: "all",
+      collectionId: "all",
       tags: [],
       showHidden: false,
       showMissingImages: false,
@@ -447,6 +482,28 @@ export function FilterSidebar({
                 </SelectContent>
               </Select>
             </div>
+
+            {showCollectionFilter && (
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <List className="h-4 w-4 text-foreground" />
+                  <label className="text-sm font-medium text-foreground">Collection</label>
+                </div>
+                <Select value={selectedCollectionId} onValueChange={handleCollectionChange}>
+                  <SelectTrigger data-testid="filter-collection-select" className="bg-background border-border text-foreground focus:ring-2 focus:ring-primary">
+                    <SelectValue placeholder="All Collections" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Collections</SelectItem>
+                    {collections.map((collection) => (
+                      <SelectItem key={collection.id} value={collection.id}>
+                        {collection.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             {/* Print Status */}
             <div className="space-y-1">

--- a/src/components/ModelDetailsDrawer.tsx
+++ b/src/components/ModelDetailsDrawer.tsx
@@ -27,6 +27,8 @@ import { Download } from "lucide-react";
 import { toast } from 'sonner';
 import type { Collection } from "../types/collection";
 import { triggerDownload } from "../utils/downloadUtils";
+import CollectionEditDrawer from "./CollectionEditDrawer";
+import { getValidCollectionCoverId } from "../utils/collectionCoverUtils";
 
 interface ModelDetailsDrawerProps {
   model: Model | null;
@@ -71,7 +73,6 @@ export function ModelDetailsDrawer({
   const [isSaving, setIsSaving] = useState(false);
   // Add-to-Collection UI state
   const [isAddToCollectionOpen, setIsAddToCollectionOpen] = useState(false);
-  const [addTargetCollectionId, setAddTargetCollectionId] = useState<string | null>(null);
   const [collections, setCollections] = useState<Collection[]>([]);
   // Remove-from-Collection UI state
   const [isRemoveFromCollectionOpen, setIsRemoveFromCollectionOpen] = useState(false);
@@ -2469,9 +2470,8 @@ export function ModelDetailsDrawer({
               variant="outline"
               size="sm"
               className="justify-start gap-2 w-full"
-              title="Add this model to an existing collection"
+              title="Add this model to a collection"
               aria-label="Add current to collection"
-              disabled={!collections || collections.length === 0}
             >
               <List className="h-4 w-4" />
               Add to Collection
@@ -3392,58 +3392,29 @@ export function ModelDetailsDrawer({
           </div>
         </ScrollArea>
 
-        {/* Add to existing collection modal */}
-        {isAddToCollectionOpen && currentModel && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setIsAddToCollectionOpen(false)}>
-            <div className="bg-card border rounded shadow-lg w-full max-w-sm p-4" onClick={(e) => e.stopPropagation()}>
-              <div className="font-semibold mb-3">Add to collection</div>
-              <div className="space-y-2">
-                <Select value={addTargetCollectionId || ''} onValueChange={(val) => setAddTargetCollectionId(val)}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a collection" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(collections || []).map(c => (
-                      <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <div className="flex gap-2 justify-end pt-2">
-                  <Button variant="ghost" size="sm" onClick={() => setIsAddToCollectionOpen(false)}>Cancel</Button>
-                  <Button
-                    size="sm"
-                    disabled={!addTargetCollectionId}
-                    onClick={async () => {
-                      try {
-                        const col = (collections || []).find(c => c.id === addTargetCollectionId);
-                        if (!col) return;
-                        const nextIds = Array.from(new Set([...(col.modelIds || []), currentModel.id]));
-                        const resp = await fetch('/api/collections', {
-                          method: 'POST',
-                          headers: { 'Content-Type': 'application/json' },
-                          body: JSON.stringify({ id: col.id, name: col.name, description: col.description || '', modelIds: nextIds, category: (col as any).category || '', tags: (col as any).tags || [], images: (col as any).images || [], coverModelId: (col as any).coverModelId })
-                        });
-                        if (resp.ok) {
-                          setIsAddToCollectionOpen(false);
-                          setAddTargetCollectionId(null);
-                          toast.success('Added to collection');
-                          // Optionally refresh collections/models for latest hidden flag
-                          try { await fetch('/api/collections', { cache: 'no-store' }); } catch {}
-                        } else {
-                          toast.error('Failed to add to collection');
-                        }
-                      } catch {
-                        toast.error('Failed to add to collection');
-                      }
-                    }}
-                  >
-                    Add
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        <CollectionEditDrawer
+          open={isAddToCollectionOpen}
+          onOpenChange={setIsAddToCollectionOpen}
+          collection={null}
+          categories={categories}
+          initialModelIds={currentModel ? [currentModel.id] : []}
+          onSaved={async (updatedCollection) => {
+            setIsAddToCollectionOpen(false);
+            toast.success('Added to collection');
+            try {
+              const resp = await fetch('/api/collections', { cache: 'no-store' });
+              if (resp.ok) {
+                const data = await resp.json();
+                if (data && data.success && Array.isArray(data.collections)) {
+                  setCollections(data.collections);
+                }
+              }
+            } catch { /* ignore */ }
+            try {
+              window.dispatchEvent(new CustomEvent('collection-updated', { detail: updatedCollection }));
+            } catch { /* ignore */ }
+          }}
+        />
 
         {/* Remove from collection modal */}
         {isRemoveFromCollectionOpen && currentModel && (
@@ -3475,7 +3446,7 @@ export function ModelDetailsDrawer({
                         const resp = await fetch('/api/collections', {
                           method: 'POST',
                           headers: { 'Content-Type': 'application/json' },
-                          body: JSON.stringify({ id: col.id, name: col.name, description: col.description || '', modelIds: nextIds, category: (col as any).category || '', tags: (col as any).tags || [], images: (col as any).images || [], coverModelId: (col as any).coverModelId })
+                          body: JSON.stringify({ id: col.id, name: col.name, description: col.description || '', modelIds: nextIds, category: (col as any).category || '', tags: (col as any).tags || [], images: (col as any).images || [], coverModelId: getValidCollectionCoverId(nextIds, (col as any).coverModelId) })
                         });
                         if (resp.ok) {
                           setIsRemoveFromCollectionOpen(false);

--- a/src/components/ModelGrid.tsx
+++ b/src/components/ModelGrid.tsx
@@ -20,6 +20,7 @@ import { SelectionModeControls } from "./SelectionModeControls";
 
 interface ModelGridProps {
   models: Model[];
+  collectionModels?: Model[];
   collections?: Collection[];
   onModelClick: (model: Model) => void;
   onOpenCollection?: (collectionId: string) => void;
@@ -64,6 +65,7 @@ function saveUiPrefs(prefs: any) {
 
 export function ModelGrid({ 
   models,
+  collectionModels = models,
   collections = [],
   onModelClick, 
   onOpenCollection,
@@ -303,6 +305,7 @@ export function ModelGrid({
                         key={`col-${c.id}`}
                         collection={c}
                         categories={config.categories || []}
+                        models={collectionModels}
                         onOpen={(id) => onOpenCollection?.(id)}
                         onChanged={() => onCollectionChanged?.()}
                         onDeleted={() => onCollectionChanged?.()}
@@ -330,6 +333,7 @@ export function ModelGrid({
                       key={`col-${c.id}`}
                       collection={c}
                       categories={config.categories || []}
+                      models={collectionModels}
                       onOpen={(id) => onOpenCollection?.(id)}
                       onChanged={() => onCollectionChanged?.()}
                       onDeleted={() => onCollectionChanged?.()}
@@ -361,6 +365,7 @@ export function ModelGrid({
                         key={`col-row-${c.id}`}
                         collection={c}
                         categories={config.categories || []}
+                        models={models}
                         onOpen={(id) => onOpenCollection?.(id)}
                         onChanged={() => onCollectionChanged?.()}
                         onDeleted={() => onCollectionChanged?.()}
@@ -516,6 +521,7 @@ export function ModelGrid({
                       key={`col-row-${c.id}`}
                       collection={c}
                       categories={config.categories || []}
+                      models={collectionModels}
                       onOpen={(id) => onOpenCollection?.(id)}
                       onChanged={() => onCollectionChanged?.()}
                       onDeleted={() => onCollectionChanged?.()}

--- a/src/components/ModelUploadDialog.tsx
+++ b/src/components/ModelUploadDialog.tsx
@@ -12,11 +12,13 @@ import { toast } from 'sonner';
 import { RendererPool } from '../utils/rendererPool';
 import TagsInput from './TagsInput';
 import { ConfigManager } from '../utils/configManager';
+import type { Collection } from '../types/collection';
+import { getValidCollectionCoverId } from '../utils/collectionCoverUtils';
 
 interface ModelUploadDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onUploaded?: () => void;
+  onUploaded?: () => void | Promise<void>;
 }
 
 export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, onClose, onUploaded }: ModelUploadDialogProps) => {
@@ -33,6 +35,8 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
   const [availableCategories, setAvailableCategories] = useState<string[]>(['Uncategorized']);
   const [selectedCategory, setSelectedCategory] = useState<string>('Uncategorized');
   const [applyTags, setApplyTags] = useState<string[]>([]);
+  const [availableCollections, setAvailableCollections] = useState<Collection[]>([]);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<string>('none');
 
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -135,6 +139,38 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
     }
   }
 
+  async function addUploadedModelsToCollection(modelIds: string[]) {
+    if (selectedCollectionId === 'none' || modelIds.length === 0) return;
+
+    const collection = availableCollections.find((entry) => entry.id === selectedCollectionId);
+    if (!collection) {
+      throw new Error('Selected collection not found');
+    }
+
+    const nextIds = Array.from(new Set([...(collection.modelIds || []), ...modelIds]));
+    const payload = {
+      id: collection.id,
+      name: collection.name,
+      description: collection.description || '',
+      modelIds: nextIds,
+      category: collection.category || '',
+      tags: collection.tags || [],
+      images: collection.images || [],
+      groups: collection.groups || [],
+      coverModelId: getValidCollectionCoverId(nextIds, collection.coverModelId),
+    };
+
+    const resp = await fetch('/api/collections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await resp.json();
+    if (!resp.ok || !data?.success) {
+      throw new Error(data?.error || 'Failed to update collection');
+    }
+  }
+
   const handleSubmit = async () => {
     if (files.length === 0) {
       toast.error('No files selected');
@@ -157,6 +193,7 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
       toast.success(`Uploaded ${(Array.isArray(data.saved) ? data.saved.length : files.length)} files`);
 
       const savedPaths: string[] = Array.isArray(data.saved) ? data.saved : [];
+      const uploadedModelIds = new Set<string>();
 
       if (generatePreviews && savedPaths.length > 0) {
         setPreviewGenerating(true);
@@ -187,6 +224,8 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
                 
                 return false;
               }) || null;
+
+              if (candidate?.id) uploadedModelIds.add(candidate.id);
 
               await applyCategoryAndTagsTo(rel, candidate);
 
@@ -251,6 +290,7 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
               
               return false;
             }) || null;
+            if (candidate?.id) uploadedModelIds.add(candidate.id);
             await applyCategoryAndTagsTo(rel, candidate);
           }
         } catch (e) {
@@ -258,8 +298,23 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
         }
       }
 
+      if (selectedCollectionId !== 'none') {
+        try {
+          const resolvedModelIds = Array.from(uploadedModelIds);
+          if (resolvedModelIds.length === 0) {
+            toast.error('Uploaded files, but could not match them to models for collection assignment');
+          } else {
+            await addUploadedModelsToCollection(resolvedModelIds);
+            toast.success('Added uploaded models to the selected collection');
+          }
+        } catch (e: any) {
+          console.error('Collection update error', e);
+          toast.error(e?.message || 'Uploaded files, but failed to update collection');
+        }
+      }
+
       setFiles([]);
-      onUploaded?.();
+      await onUploaded?.();
       onClose();
     } catch (err: any) {
       console.error('Upload error', err);
@@ -277,6 +332,8 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
   setNewFolderName('');
   setSelectedCategory('Uncategorized');
   setApplyTags([]);
+    setSelectedCollectionId('none');
+    setAvailableCollections([]);
 
     (async () => {
       try {
@@ -285,6 +342,19 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
         const data = await resp.json();
         if (data && Array.isArray(data.folders)) setFolders(Array.from(new Set(['uploads', ...data.folders])));
       } catch (e) {
+        // ignore
+      }
+    })();
+
+    (async () => {
+      try {
+        const resp = await fetch('/api/collections', { cache: 'no-store' });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (data && data.success && Array.isArray(data.collections)) {
+          setAvailableCollections(data.collections);
+        }
+      } catch {
         // ignore
       }
     })();
@@ -329,7 +399,7 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
         <DialogHeader>
           <DialogTitle>Upload 3MF / STL Files</DialogTitle>
           <DialogDescription>
-            Choose destination, optional category and tags to apply to all uploaded models, and optionally generate previews.
+            Choose destination, optional category and tags to apply to all uploaded models, optionally add them to an existing collection, and optionally generate previews.
           </DialogDescription>
         </DialogHeader>
 
@@ -405,6 +475,29 @@ export const ModelUploadDialog: React.FC<ModelUploadDialogProps> = ({ isOpen, on
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+
+              <div className="mb-4">
+                <div className="text-sm text-foreground mb-1">Add to collection</div>
+                <Select value={selectedCollectionId} onValueChange={(v) => setSelectedCollectionId(v)}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Do not add to a collection" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Do not add to a collection</SelectItem>
+                    {availableCollections
+                      .slice()
+                      .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+                      .map((collection) => (
+                        <SelectItem key={collection.id} value={collection.id}>
+                          {collection.name}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Uploaded models will be appended to the selected collection after processing.
+                </p>
               </div>
 
               <div className="mb-4">

--- a/src/components/SelectionModeControls.tsx
+++ b/src/components/SelectionModeControls.tsx
@@ -9,6 +9,8 @@ interface SelectionModeControlsProps {
   onExitSelectionMode?: () => void;
   onBulkEdit?: () => void | Promise<void>;
   onCreateCollection?: () => void;
+  createActionLabel?: string;
+  createActionTitle?: string;
   onBulkDelete?: () => void | Promise<void>;
   onSelectAll?: () => void;
   onDeselectAll?: () => void;
@@ -24,6 +26,8 @@ export function SelectionModeControls({
   onExitSelectionMode,
   onBulkEdit,
   onCreateCollection,
+  createActionLabel = "Collection",
+  createActionTitle = "Create collection from selection",
   onBulkDelete,
   onSelectAll,
   onDeselectAll,
@@ -81,11 +85,11 @@ export function SelectionModeControls({
               size="sm"
               onClick={onCreateCollection}
               className="gap-2"
-              title="Create collection from selection"
+              title={createActionTitle}
               data-testid="selection-mode-collection-button"
             >
               <List className="h-4 w-4" />
-              <span className="hidden sm:inline">Collection</span>
+              <span className="hidden sm:inline">{createActionLabel}</span>
             </Button>
           )}
 

--- a/src/types/collection.ts
+++ b/src/types/collection.ts
@@ -1,9 +1,20 @@
+export interface CollectionGroup {
+  id: string;
+  name: string;
+  description?: string;
+  modelIds: string[];
+  created?: string;
+  lastModified?: string;
+}
+
 export interface Collection {
   id: string;
   name: string;
   description?: string;
   // Model IDs included in this collection
   modelIds: string[];
+  // Optional named subsets used to collapse variants inside a collection
+  groups?: CollectionGroup[];
   // Optional: choose a model to represent the collection cover
   coverModelId?: string;
   // Optional: user categorization and tags for the collection itself

--- a/src/utils/collectionCoverUtils.ts
+++ b/src/utils/collectionCoverUtils.ts
@@ -1,0 +1,43 @@
+import type { Collection } from "../types/collection";
+import type { Model } from "../types/model";
+import { resolveModelThumbnail } from "./thumbnailUtils";
+
+export function getCollectionCoverImages(collection: Collection, models: Model[] = [], limit = 4): string[] {
+  const modelMap = new Map(models.map((model) => [model.id, model]));
+  const thumbnails = (collection?.modelIds || [])
+    .map((modelId) => modelMap.get(modelId))
+    .map((model) => (model ? resolveModelThumbnail(model) : ""))
+    .filter((src): src is string => Boolean(src));
+
+  if (thumbnails.length > 0) {
+    return thumbnails.slice(0, limit);
+  }
+
+  if (Array.isArray(collection?.images) && collection.images.length > 0) {
+    return collection.images.slice(0, 1);
+  }
+
+  return [];
+}
+
+export function resolveCollectionCoverImage(collection: Collection, models: Model[] = []): string {
+  if (collection?.coverModelId) {
+    const coverModel = models.find((model) => model.id === collection.coverModelId);
+    const coverSrc = coverModel ? resolveModelThumbnail(coverModel) : "";
+    if (coverSrc) return coverSrc;
+  }
+
+  if (Array.isArray(collection?.images) && collection.images.length > 0) {
+    return collection.images[0];
+  }
+
+  return "";
+}
+
+export function getValidCollectionCoverId(modelIds: string[] = [], requestedCoverModelId?: string): string | undefined {
+  if (!Array.isArray(modelIds) || modelIds.length === 0) return undefined;
+  if (requestedCoverModelId && modelIds.includes(requestedCoverModelId)) {
+    return requestedCoverModelId;
+  }
+  return modelIds[0];
+}

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -6,6 +6,7 @@ export interface FilterState {
   printStatus: string;
   license: string;
   fileType: string;
+  collectionId?: string;
   tags: string[];
   showHidden: boolean;
   showMissingImages: boolean;

--- a/tests/components/CollectionGrid.groups.test.tsx
+++ b/tests/components/CollectionGrid.groups.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import React from 'react'
+import CollectionGrid from '../../src/components/CollectionGrid'
+
+describe('CollectionGrid groups', () => {
+  const models = [
+    {
+      id: 'm1',
+      name: 'Dragon Small',
+      category: 'Figures',
+      tags: ['small'],
+      isPrinted: false,
+      printTime: '',
+      filamentUsed: '',
+      fileSize: '',
+      description: '',
+      modelUrl: '/models/m1.3mf',
+      license: '',
+      filePath: '/tmp/m1.3mf',
+      printSettings: { layerHeight: '', infill: '', nozzle: '' },
+    },
+    {
+      id: 'm2',
+      name: 'Dragon Large',
+      category: 'Figures',
+      tags: ['large'],
+      isPrinted: false,
+      printTime: '',
+      filamentUsed: '',
+      fileSize: '',
+      description: '',
+      modelUrl: '/models/m2.3mf',
+      license: '',
+      filePath: '/tmp/m2.3mf',
+      printSettings: { layerHeight: '', infill: '', nozzle: '' },
+    },
+    {
+      id: 'm3',
+      name: 'Standalone Vase',
+      category: 'Decor',
+      tags: [],
+      isPrinted: false,
+      printTime: '',
+      filamentUsed: '',
+      fileSize: '',
+      description: '',
+      modelUrl: '/models/m3.3mf',
+      license: '',
+      filePath: '/tmp/m3.3mf',
+      printSettings: { layerHeight: '', infill: '', nozzle: '' },
+    },
+  ] as any
+
+  it('renders group cards and reveals grouped models when expanded', () => {
+    render(
+      <CollectionGrid
+        name="Favorites"
+        modelIds={['m1', 'm2', 'm3']}
+        models={models}
+        onBack={vi.fn()}
+        onModelClick={vi.fn()}
+        activeCollection={{
+          id: 'col-1',
+          name: 'Favorites',
+          modelIds: ['m1', 'm2', 'm3'],
+          groups: [
+            { id: 'grp-1', name: 'Dragon Model', description: 'Scaled variants', modelIds: ['m1', 'm2'] },
+          ],
+        }}
+      />
+    )
+
+    expect(screen.getByText('Groups')).toBeInTheDocument()
+    expect(screen.getByText('Dragon Model')).toBeInTheDocument()
+    expect(screen.getByText('Standalone Vase')).toBeInTheDocument()
+    expect(screen.queryByText('Dragon Small')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /dragon model/i }))
+
+    expect(screen.getByText('Dragon Small')).toBeInTheDocument()
+    expect(screen.getByText('Dragon Large')).toBeInTheDocument()
+  })
+})

--- a/tests/components/FilterSidebar.collectionsOption.test.tsx
+++ b/tests/components/FilterSidebar.collectionsOption.test.tsx
@@ -46,6 +46,7 @@ import { FilterSidebar } from '../../src/components/FilterSidebar'
 describe('FilterSidebar file type includes Collections', () => {
   const categories = [{ id: 'cat1', label: 'Organizers', icon: 'Folder' }] as any
   const models = [] as any
+  const collections = [{ id: 'col-1', name: 'Dragon Set', modelIds: ['m1'] }] as any
 
   it('shows Collections option and triggers onFilterChange with fileType collections', async () => {
     const onFilterChange = vi.fn()
@@ -58,6 +59,7 @@ describe('FilterSidebar file type includes Collections', () => {
         onSettingsClick={() => {}}
         categories={categories}
         models={models}
+        collections={collections}
         initialFilters={{ search: '', category: 'all', printStatus: 'all', license: 'all', fileType: 'all', tags: [], showHidden: false, showMissingImages: false }}
       />
     )
@@ -70,5 +72,29 @@ describe('FilterSidebar file type includes Collections', () => {
     expect(onFilterChange).toHaveBeenCalled()
     const last = onFilterChange.mock.calls.at(-1)?.[0]
     expect(last?.fileType).toBe('collections')
+  })
+
+  it('triggers onFilterChange with the selected collection id', async () => {
+    const onFilterChange = vi.fn()
+    render(
+      <FilterSidebar
+        onFilterChange={onFilterChange}
+        onCategoryChosen={() => {}}
+        isOpen
+        onClose={() => {}}
+        onSettingsClick={() => {}}
+        categories={categories}
+        models={models}
+        collections={collections}
+        initialFilters={{ search: '', category: 'all', printStatus: 'all', license: 'all', fileType: 'all', collectionId: 'all', tags: [], showHidden: false, showMissingImages: false }}
+      />
+    )
+
+    const collectionSelect = screen.getByTestId('filter-collection-select') as HTMLSelectElement
+    fireEvent.change(collectionSelect, { target: { value: 'col-1' } })
+
+    expect(onFilterChange).toHaveBeenCalled()
+    const last = onFilterChange.mock.calls.at(-1)?.[0]
+    expect(last?.collectionId).toBe('col-1')
   })
 })

--- a/tests/components/ModelDetailsDrawer.test.tsx
+++ b/tests/components/ModelDetailsDrawer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { ModelDetailsDrawer } from '../../src/components/ModelDetailsDrawer';
 import type { Model } from '../../src/types/model';
@@ -25,6 +25,14 @@ const baseProps = {
   categories: [],
 };
 
+beforeEach(() => {
+  // @ts-ignore
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ success: true, collections: [] }),
+  });
+});
+
 describe('ModelDetailsDrawer currency symbol', () => {
   it('displays $ before price by default', () => {
     render(<ModelDetailsDrawer {...baseProps} currencySymbol="$" />);
@@ -40,5 +48,23 @@ describe('ModelDetailsDrawer currency symbol', () => {
     const modelNoPrice = { ...mockModel, price: 0 };
     render(<ModelDetailsDrawer {...baseProps} model={modelNoPrice} currencySymbol="$" />);
     expect(screen.queryByText('Price')).not.toBeInTheDocument();
+  });
+});
+
+describe('ModelDetailsDrawer collection actions', () => {
+  it('opens the shared collection drawer even when no collections exist yet', async () => {
+    render(<ModelDetailsDrawer {...baseProps} />);
+
+    const button = await screen.findByRole('button', { name: /add current to collection/i });
+    expect(button).toBeEnabled();
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Collection' })).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText('Collection name')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Existing' })).toBeInTheDocument();
   });
 });

--- a/tests/server/collections.test.ts
+++ b/tests/server/collections.test.ts
@@ -39,4 +39,34 @@ describe('Collections API', () => {
     expect(del.status).toBe(200);
     expect(del.body.success).toBe(true);
   });
+
+  it('normalizes groups and keeps them in sync with collection membership', async () => {
+    const create = await request(app).post('/api/collections').send({
+      name: 'Dragon Variants',
+      modelIds: ['loose-1'],
+      groups: [
+        { name: 'Dragon Model', modelIds: ['m1', 'm2', 'm1'] },
+        { name: 'Second Group', modelIds: ['m2', 'm3'] },
+      ],
+    });
+
+    expect(create.status).toBe(200);
+    expect(create.body.collection.modelIds).toEqual(['loose-1', 'm1', 'm2', 'm3']);
+    expect(create.body.collection.groups).toHaveLength(2);
+    expect(create.body.collection.groups[0].modelIds).toEqual(['m1', 'm2']);
+    expect(create.body.collection.groups[1].modelIds).toEqual(['m3']);
+
+    const id = create.body.collection.id;
+    const update = await request(app).post('/api/collections').send({
+      id,
+      name: 'Dragon Variants',
+      modelIds: ['loose-1', 'm1', 'm3'],
+    });
+
+    expect(update.status).toBe(200);
+    expect(update.body.collection.modelIds).toEqual(['loose-1', 'm1', 'm3']);
+    expect(update.body.collection.groups).toHaveLength(2);
+    expect(update.body.collection.groups[0].modelIds).toEqual(['m1']);
+    expect(update.body.collection.groups[1].modelIds).toEqual(['m3']);
+  });
 });


### PR DESCRIPTION
# Introduce Collections for Organizing Related 3D Models

## Summary

This PR adds a full Collections workflow to help organize related 3D models into cleaner, easier-to-browse groups.

Collections make it possible to bundle variants of the same design, filter the library by collection, manage collection membership from multiple entry points, and present grouped content with a more compact visual representation.

## Highlights

- Create collections to group related models together
- Create empty collections in advance for future use
- Add models to collections from the model details panel
- Add uploaded files directly into an existing collection during upload
- Organize variants inside a collection using named groups
- Filter the library by collection from the left sidebar
- Browse collections from a dedicated collections page
- Display collections with automatic preview imagery built from models inside the collection

## New Capabilities

### Collections
- Users can create named collections for related models
- Collections support description, category, tags, and optional images
- Collections can contain models immediately or remain empty until used later

### Grouping Within a Collection
- Users can group related variants inside a collection
- Groups help reduce clutter when a collection contains multiple versions of the same base design
- Grouped items can be expanded within the collection view to access individual variants

### Collection Assignment
- Models can be added to collections from the model details drawer
- Newly uploaded files can be assigned to an existing collection during upload
- Empty collections can be created directly from the collections page for planned organization workflows

### Collection Filtering
- A collection filter is available in the left sidebar
- Users can narrow the visible library to a single collection
- Collection-aware browsing makes it easier to focus on a specific model family

### Collection Browsing Experience
- Collections have their own dedicated page
- Collection cards show a preview collage generated from models in the collection
- Opening a collection shows its contents in a dedicated collection view

## User Impact

This feature is aimed at users with libraries containing many near-identical models, scaled variants, or slight geometry revisions.

With Collections, users can:

- Keep related models together under one named container
- Reduce visual clutter in the main library
- Prepare empty organizational buckets before importing files
- Add uploads straight into an existing workflow without extra cleanup
- Find the right variant faster by browsing within a focused collection

## Example Use Cases

- Group multiple sizes of the same dragon model into one collection
- Create a collection for a project before importing all related files
- Upload several new variants directly into an existing design family
- Keep remix versions, detail levels, or print-specific edits together in one place

## Testing

Manually verified:

- Creating an empty collection from the collections page
- Creating a collection from selected models
- Adding a model to a collection from the model details panel
- Adding uploaded files to an existing collection during upload
- Viewing collection contents from the dedicated collections page
- Filtering the library by a selected collection
- Grouping related models inside a collection
- Rendering collection preview cards from models contained in the collection